### PR TITLE
Update documentation with latest versions of Bacalhau + Lilypad, fix some critical issues and restructure document for better flow

### DIFF
--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -6,15 +6,15 @@ The below are instructions for running on the public Lilypad testnet.
 
 The testnet has a base currency of ETH, as well as a utility token called LP. You will receive LP to pay for jobs (and nodes to stake).
 
-Metamask:
+### Metamask
+We suggest using Metamask with custom settings to make things easier. Once you have it installed and setup, here are the settings you should use:
 - Network name: Lilypad v2 Aurora testnet
 - New RPC URL: [http://testnet.lilypad.tech:8545](http://testnet.lilypad.tech:8545)
 - Chain ID: 1337
 - Currency symbol: ETH
 - Block explorer URL: (leave blank)
 
-Fund your wallet with ETH and LP
-
+### Fund your wallet with ETH and LP
 To obtain funds, go to [http://faucet.lilypad.tech:8080](http://faucet.lilypad.tech:8080)
 
 The faucet will give you both ETH (to pay for gas) and LP (to stake and pay for jobs).

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -108,7 +108,7 @@ sudo systemctl start bacalhau
 sudo systemctl start lilypad-resource-provider
 ```
 
-Check they are running with `systemctl` status as usual, and debug with `journalctl` if needed - eg, `sudo journalctl -uf lilypad-resource-provider` will give you the live output from your Lilypad node. Please report issues on Bacalhau `#bacalhau-lilypad` Slack. You should see your resource provider start accepting jobs on the network in the logs.
+Check they are running with `systemctl` status as usual, and debug with `journalctl` if needed - eg, `sudo journalctl -uf lilypad-resource-provider` will give you the live output from your Lilypad node. Please report issues on Bacalhau `#lilypad-general` Slack. You should see your resource provider start accepting jobs on the network in the logs.
 
 ### Security
 If you want to allowlist only certain modules (e.g. Stable Diffusion modules), so that you can control exactly what code runs on your nodes (which you can audit to ensure that they are secure and will have no negative impact on your nodes), you can do that by setting an environment variable `OFFER_MODULES` in the GPU provider to a comma separated list of module names, e.g. “sdxl:v0.9-lilypad1,stable-diffusion:v0.0.1”

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -52,7 +52,8 @@ WEB3_PRIVATE_KEY=YOUR_PRIVATE_KEY (the private key from your metamask wallet)
 
 This is the key where you will get paid in LP tokens for jobs run on the network. 
 
-Install systemd unit for Bacalhau:
+### Install systemd unit for Bacalhau:
+Open `/etc/systemd/system/bacalhau.service` in your favourite editor (hint: `sudo editor /etc/systemd/system/bacalhau.service`)
 ```
 [Unit]
 Description=Lilypad V2 Bacalhau
@@ -70,9 +71,11 @@ ExecStart=/usr/bin/bacalhau serve --node-type compute,requester --peer none --pr
 
 [Install]
 WantedBy=multi-user.target
+```
 
-Install systemd unit for GPU provider
-
+### Install systemd unit for GPU provider
+Open `/etc/systemd/system/lilypad-resource-provider.service` in your favourite editor (hint: `sudo editor /etc/systemd/system/lilypad-resource-provider.service`)
+```
 [Unit]
 Description=Lilypad V2 Resource Provider GPU
 After=network-online.target
@@ -94,18 +97,20 @@ ExecStart=/usr/bin/lilypad resource-provider
 WantedBy=multi-user.target
 ```
 
+Reload systemd's units/daemons (you will need to do this again if you ever change the systemd unit files that we wrote, above)
+```
+sudo systemctl daemon-reload
+```
+
 Start systemd units:
 ```
 sudo systemctl start bacalhau
-sudo systemctl start resource-provider-gpu
+sudo systemctl start lilypad-resource-provider
 ```
 
-Check they are running with `systemctl` status as usual, and debug with `journalctl` if needed. Please report issues on Bacalhau `#bacalhau-lilypad` Slack. You should see your resource provider start accepting jobs on the network in the logs.
+Check they are running with `systemctl` status as usual, and debug with `journalctl` if needed - eg, `sudo journalctl -uf lilypad-resource-provider` will give you the live output from your Lilypad node. Please report issues on Bacalhau `#bacalhau-lilypad` Slack. You should see your resource provider start accepting jobs on the network in the logs.
 
 ### Security
 If you want to allowlist only certain modules (e.g. Stable Diffusion modules), so that you can control exactly what code runs on your nodes (which you can audit to ensure that they are secure and will have no negative impact on your nodes), you can do that by setting an environment variable `OFFER_MODULES` in the GPU provider to a comma separated list of module names, e.g. “sdxl:v0.9-lilypad1,stable-diffusion:v0.0.1”
 
-See https://github.com/bacalhau-project/lilypad/#available-modules for a list of modules
-
-
-
+See https://github.com/bacalhau-project/lilypad/#available-modules for a list of modules.

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -50,7 +50,7 @@ You will need to create an environment file for your node.
 WEB3_PRIVATE_KEY=YOUR_PRIVATE_KEY (the private key from your metamask wallet)
 ```
 
-This is the key where you will get paid in LP tokens for jobs run on the network. 
+This is the key where you will get paid in LP tokens for jobs run on the network.
 
 ### Install systemd unit for Bacalhau:
 Open `/etc/systemd/system/bacalhau.service` in your favourite editor (hint: `sudo editor /etc/systemd/system/bacalhau.service`)

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -29,7 +29,7 @@ The faucet will give you both ETH (to pay for gas) and LP (to stake and pay for 
 ### Install Bacalhau
 ```
 cd /tmp
-wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.1.2/bacalhau_v1.1.2_linux_amd64.tar.gz
+wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.0.3/bacalhau_v1.0.3_linux_amd64.tar.gz
 tar xfv bacalhau_v1.0.3_linux_amd64.tar.gz
 sudo mv bacalhau /usr/bin/bacalhau
 sudo mkdir -p /app/data/ipfs
@@ -38,7 +38,7 @@ sudo chown -R $USER /app/data
 
 ### Install Lilypad
 ```
-curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-275e5f3/lilypad
+curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-6afc1cc/lilypad
 chmod +x lilypad
 sudo mv lilypad /usr/bin
 ```

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -4,7 +4,7 @@ The below are instructions for running on the public Lilypad testnet.
 
 ## Adding a node
 
-The testnet has a base currency of ETH and you will also get LP to pay for jobs (and nodes to stake).
+The testnet has a base currency of ETH, as well as a utility token called LP. You will receive LP to pay for jobs (and nodes to stake).
 
 Metamask:
 - Network name: Lilypad v2 Aurora testnet

--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -29,7 +29,7 @@ The faucet will give you both ETH (to pay for gas) and LP (to stake and pay for 
 ### Install Bacalhau
 ```
 cd /tmp
-wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.0.3/bacalhau_v1.0.3_linux_amd64.tar.gz
+wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.1.2/bacalhau_v1.1.2_linux_amd64.tar.gz
 tar xfv bacalhau_v1.0.3_linux_amd64.tar.gz
 sudo mv bacalhau /usr/bin/bacalhau
 sudo mkdir -p /app/data/ipfs
@@ -38,19 +38,19 @@ sudo chown -R $USER /app/data
 
 ### Install Lilypad
 ```
-curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-6afc1cc/lilypad
+curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-275e5f3/lilypad
 chmod +x lilypad
 sudo mv lilypad /usr/bin
 ```
 
 ### Write env file
-
+You will need to create an environment file for your node.
 `/app/lilypad/resource-provider-gpu.env` should contain:
 ```
-export WEB3_PRIVATE_KEY=0x… (the private key from your metamask wallet)
+WEB3_PRIVATE_KEY=YOUR_PRIVATE_KEY (the private key from your metamask wallet)
 ```
 
-This is the key where you will get paid in LP tokens for jobs run on the network.
+This is the key where you will get paid in LP tokens for jobs run on the network. 
 
 Install systemd unit for Bacalhau:
 ```


### PR DESCRIPTION
This document makes a few hopefully uncontroversial changes:

* It expands on what the LP and ETH tokens are in this context
* It adds some more structure and Markdown formatting for the Metamask and funding instructions
* It ~~updates the versions of Bacalhau and Lilypad and~~ adds some missing context
* It adds even more formatting for all the systemd instructions as well as explicitly telling the user how to check the logs using journalctl instead of expecting they already know how to use it
* It removes extraneous newlines at the end of the document (and currently accidentally adds a trailing space on one line, that needs a fix before we merge ;))
* **Breaking change:** it renames the "resource-provider-gpu" systemd service to "lilypad-resource-provider"
* It updates the Slack channel name to the new #lilypad-general channel name
* It splits a code block that was accidentally rendering as one code block but should actually have been two.