### PR TITLE
Update run-a-node.md to fix naming issue

### DIFF
--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -39,8 +39,8 @@ sudo chown -R $USER /app/data
 ### Install Lilypad
 ```
 curl -sSL -o lilypad https://github.com/bacalhau-project/lilypad/releases/download/v2.0.0-d63a7ff/lilypad-linux-amd64
-chmod +x lilypad-linux-amd64
-sudo mv lilypad-linux-amd64 /usr/bin/lilypad
+chmod +x lilypad
+sudo mv lilypad /usr/bin/lilypad
 ```
 
 ### Write env file


### PR DESCRIPTION
See the patch - we're curling with -o lilypad so we know we'll always end up with that filename, we don't actually need to specify anything other than lilypad when chmod-ing and mv-ing the result.